### PR TITLE
examples: Add iommu arguments to x86_64-q35-base.conf

### DIFF
--- a/examples/vm/x86_64-q35-base.conf
+++ b/examples/vm/x86_64-q35-base.conf
@@ -20,6 +20,7 @@ fi
 
 : "${GUEST_DISPLAY:="0"}"
 : "${GUEST_VIOMMU:="1"}"
+: "${GUEST_VIOMMU_ARGS:="intel-iommu,intremap=on"}"
 : "${GUEST_CPU:="host"}"
 : "${GUEST_SMP:="4"}"
 : "${GUEST_MEMORY:="8G"}"
@@ -46,7 +47,7 @@ _setup_x86_64_q35_base() {
 
   # guest iommu
   if [[ $GUEST_VIOMMU -ne 0 ]]; then
-    QEMU_PARAMS+=("-device" "intel-iommu,intremap=on")
+    QEMU_PARAMS+=("-device" "$GUEST_VIOMMU_ARGS")
   fi
 
   # simple user-level networking


### PR DESCRIPTION
It is useful to over-ride the default qemu parameters of the iommu from custom configuration files that source x86_64-q35-base.conf. Add GUEST_VIOMMU_ARGS that defaults to the previous hard-coded value. Behaviour will not change unless GUEST_VIOMMU_ARGS is set.