### PR TITLE
vmctl-init-conf: add initialization script support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ QEMU NVMe Testing Galore!
 running.
 
 
-## Getting Started
+## Getting Started (Manual Mode)
 
 1. Clone the `vmctl` repository.
 
@@ -56,6 +56,17 @@ running.
 
 [archbase]: https://github.com/OpenMPDK/archbase
 [ubuntu-cloud-image]: https://cloud-images.ubuntu.com
+
+## Getting Started (Helper Mode)
+
+1. Clone the `vmctl` repository.
+
+2. Run `source vmctl-init-conf <confdir>`.
+
+   **Note** A `<confdir>` will be created with all the examples and `vmctl`
+   command ready. Edit the examples as you need.
+
+3. Example: Run `vmctl --config <config> run`.
 
 
 ## Virtual Machine Configurations

--- a/vmctl-init-conf
+++ b/vmctl-init-conf
@@ -1,0 +1,51 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-late
+#
+# Run source vmctl-init-conf <confdir>
+
+usage() {
+	echo "Usage: source $0 <confdir>"
+}
+
+if [ -z "$1" ]; then
+	usage
+	return 2
+fi
+
+if [ "$1" = '--help' ] || [ "$1" = '-h' ]; then
+	usage
+	return 2
+fi
+
+CONFDIR="$1"
+if [ -n "${BASH_SOURCE[0]}" ]; then
+	VMCTLDIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+else
+	VMCTLDIR=$(dirname "$(realpath "$0")")
+fi
+EXAMPLESDIR=$VMCTLDIR/examples/vm
+
+# Create CONFDIR if necessary
+if [ ! -d "$CONFDIR" ]; then
+	mkdir --parent "$CONFDIR"
+	if [ $? -ne 0 ]; then
+		return 1
+	fi
+	cp --recursive --verbose "$EXAMPLESDIR"/* "$CONFDIR"
+	if [ $? -ne 0 ]; then
+		return 1
+	fi
+fi
+
+# Ensure vmctl is available
+if ! command -v vmctl &> /dev/null; then
+	# Add the parent directory of this script to PATH
+	export PATH="$VMCTLDIR:$PATH"
+	if ! command -v vmctl &> /dev/null; then
+		echo "Error: vmctl tool is still not found after adding $VMCTLDIR to PATH."
+		return 1
+	fi
+fi
+
+cd $CONFDIR
+vmctl --help


### PR DESCRIPTION
To initialize a configuration folder with vmctl command in PATH and all examples. If the configuration folder exists, just ensure vmctl command is available.

vmctl$ source vmctl-init-conf confdir
vmctl/confdir$ vmctl --help

Next time, repeating the first command would only navigate the user to the confdir.

Provide guidance of this new script in README.