### PR TITLE
ssh: Get default ssh values from config file

### DIFF
--- a/cmd/ssh
+++ b/cmd/ssh
@@ -29,10 +29,6 @@ _ssh() {
   eval set -- "$tmp"
   unset tmp
 
-  local port="$GUEST_SSH_PORT"
-  local user="$GUEST_SSH_USER"
-  local cmd=""
-
   while true; do
     case "$1" in
       '-w' | '--wait' )
@@ -60,6 +56,10 @@ _ssh() {
   done
 
   _load_vm
+
+  : "${port:="${GUEST_SSH_PORT}"}"
+  : "${user:="${GUEST_SSH_USER}"}"
+  : "${cmd:=""}"
 
   if ! _is_running; then
     _fatal 1 "$VMNAME does not appear to be running"


### PR DESCRIPTION
Calling _load_vm after giving value to "port", "user" and "cmd" means that the values set in the config file will not be used. Fix this situation by assigning the config (default) value when they have no value.