### PR TITLE
treewide: normalize the shebang to bash through /usr/bin/env

### DIFF
--- a/cmd/console
+++ b/cmd/console
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash/
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/cmd/kill
+++ b/cmd/kill
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/cmd/log
+++ b/cmd/log
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/cmd/monitor
+++ b/cmd/monitor
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/cmd/poweroff
+++ b/cmd/poweroff
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/cmd/run
+++ b/cmd/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/cmd/ssh
+++ b/cmd/ssh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/cmd/vars
+++ b/cmd/vars
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/common/defaults
+++ b/common/defaults
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/common/rc
+++ b/common/rc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/common/shellcheck
+++ b/common/shellcheck
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/contrib/generate-cloud-config-seed-freebsd.sh
+++ b/contrib/generate-cloud-config-seed-freebsd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 set -euo pipefail

--- a/contrib/generate-cloud-config-seed.sh
+++ b/contrib/generate-cloud-config-seed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 set -euo pipefail

--- a/examples/vm/aarch64-virt-base.conf
+++ b/examples/vm/aarch64-virt-base.conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Q35-based base vm config
 #

--- a/examples/vm/common.conf
+++ b/examples/vm/common.conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # vmctl run parameters
 QEMU_IMG=$(/usr/bin/which qemu-img)

--- a/examples/vm/nvme-aarch64.conf
+++ b/examples/vm/nvme-aarch64.conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 QEMU_SYSTEM_AARCH64=$(/usr/bin/which qemu-system-aarch64)
 GUEST_BOOT_BASE="img/debian-13-genericcloud-arm64.qcow2"

--- a/examples/vm/nvme-cortex-a57.conf
+++ b/examples/vm/nvme-cortex-a57.conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 GUEST_BOOT_BASE="img/debian-13-genericcloud-arm64.qcow2"
 GUEST_CPU="cortex-a57"

--- a/examples/vm/nvme-vfio.conf
+++ b/examples/vm/nvme-vfio.conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "x86_64-q35-base.conf"
 

--- a/examples/vm/nvme.conf
+++ b/examples/vm/nvme.conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 QEMU_SYSTEM_X86_64=$(/usr/bin/which qemu-system-x86_64)
 

--- a/examples/vm/subsys.conf
+++ b/examples/vm/subsys.conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "x86_64-q35-base.conf"
 

--- a/examples/vm/x86_64-q35-base.conf
+++ b/examples/vm/x86_64-q35-base.conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Q35-based base vm config
 #

--- a/examples/vm/zns.conf
+++ b/examples/vm/zns.conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # use the same boot image as the nvme configuration
 GUEST_BOOT="img/nvme.qcow2"

--- a/lib/qemu/nvme
+++ b/lib/qemu/nvme
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/lib/qemu/pcie
+++ b/lib/qemu/pcie
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/lib/qemu/rc
+++ b/lib/qemu/rc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #

--- a/vmctl-init-conf
+++ b/vmctl-init-conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-late
 #
 # Run source vmctl-init-conf <confdir>


### PR DESCRIPTION
This is relevant for when bash is not in its expected place. Like when using nix.